### PR TITLE
리펙터링: AuditingFields 클래스를 추상 클래스로 변경

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class AuditingFields {
+public abstract class AuditingFields {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate


### PR DESCRIPTION
엔티티에서 상속을 해서 사용해야 하는 목적에 더 잘 맞게 `abstract` 키워드 추가